### PR TITLE
Ensure workout audio cues play alongside other apps

### DIFF
--- a/workout-time/index.html
+++ b/workout-time/index.html
@@ -892,46 +892,6 @@
                 display: block;
             }
 
-            .fullscreen-toggle {
-                position: fixed;
-                top: 82px;
-                left: 20px;
-                z-index: 1001;
-                width: 50px;
-                height: 50px;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                border: none;
-                border-radius: 8px;
-                background: var(--card-bg);
-                color: var(--accent-color);
-                box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-                cursor: pointer;
-                transition: box-shadow 0.2s ease, color 0.2s ease,
-                    background 0.2s ease;
-            }
-
-            .fullscreen-toggle:hover,
-            .fullscreen-toggle:focus-visible {
-                box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
-                color: var(--accent-contrast);
-                outline: none;
-            }
-
-            .fullscreen-toggle:active {
-                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-            }
-
-            .fullscreen-toggle[aria-pressed="true"] {
-                color: var(--accent-contrast);
-            }
-
-            .fullscreen-toggle .bi {
-                font-size: 1.5rem;
-                line-height: 1;
-            }
-
             .plan-set-indicator {
                 position: absolute;
                 left: 24px;
@@ -1671,11 +1631,6 @@
                     grid-template-columns: 1fr;
                 }
 
-                .fullscreen-toggle {
-                    top: 88px;
-                    left: 20px;
-                }
-
                 .plan-set-indicator {
                     position: static;
                     margin-top: 16px;
@@ -1774,17 +1729,6 @@
         <!-- Mobile hamburger menu -->
         <button class="hamburger" id="hamburger" type="button" onclick="app.toggleSidebar()">
             <i class="bi bi-list" aria-hidden="true"></i>
-        </button>
-
-        <button
-            type="button"
-            class="fullscreen-toggle"
-            id="fullscreenToggle"
-            aria-pressed="false"
-            aria-label="Enter full screen"
-        >
-            <i class="bi bi-arrows-fullscreen" aria-hidden="true"></i>
-            <span class="sr-only">Enter full screen</span>
         </button>
 
         <!-- Overlay for mobile -->


### PR DESCRIPTION
## Summary
- add audio context unlock helpers so repetition and weight adjust cues resume when the browser suspends audio
- request interactive latency hints and automatically re-arm resume listeners after interruptions
- remove the fullscreen toggle UI and its related styling and logic from the workout controller

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690bc7f68da88321b64a7e8959c56761