### PR TITLE
Improve weight adjuster button focus treatment

### DIFF
--- a/workout-time/index.html
+++ b/workout-time/index.html
@@ -757,6 +757,11 @@
                 border: none;
                 cursor: pointer;
                 background: transparent;
+                appearance: none;
+                -webkit-appearance: none;
+                -webkit-tap-highlight-color: transparent;
+                outline: none;
+                box-shadow: none;
                 display: flex;
                 align-items: center;
                 justify-content: center;
@@ -765,6 +770,16 @@
                 color: #ffffff;
                 z-index: 2;
                 transition: background 0.2s ease;
+            }
+
+            .weight-adjuster-segment:focus-visible {
+                box-shadow:
+                    inset 0 0 0 2px rgba(255, 255, 255, 0.25),
+                    0 0 0 4px rgba(0, 0, 0, 0.18);
+            }
+
+            .weight-adjuster-segment::-moz-focus-inner {
+                border: 0;
             }
 
             .weight-adjuster-segment:hover {


### PR DESCRIPTION
## Summary
- remove the tap highlight and Firefox inner focus border from the weight adjuster controls so the circle edge stays clean
- add a custom focus-visible ring to preserve an accessible focus state without reintroducing the white outlines

## Testing
- not run (UI-only change)
- manual preview at http://127.0.0.1:8000/workout-time/index.html

------
https://chatgpt.com/codex/tasks/task_e_690bd2aaee44832186a89778a80b6332