### PR TITLE
Fix single-cable load tracking

### DIFF
--- a/workout-time/index.html
+++ b/workout-time/index.html
@@ -3226,14 +3226,14 @@
                         <!-- Stats Grid -->
                         <div class="stats-grid">
                             <div class="stat-card">
-                                <div class="stat-label">Right Cable Load</div>
-                                <div class="stat-value" id="loadA">
+                                <div class="stat-label">Left Cable Load</div>
+                                <div class="stat-value" id="loadB">
                                     0.0 <span class="stat-unit">kg</span>
                                 </div>
                             </div>
                             <div class="stat-card">
-                                <div class="stat-label">Left Cable Load</div>
-                                <div class="stat-value" id="loadB">
+                                <div class="stat-label">Right Cable Load</div>
+                                <div class="stat-value" id="loadA">
                                     0.0 <span class="stat-unit">kg</span>
                                 </div>
                             </div>


### PR DESCRIPTION
When doing 1 cable exercises, the Personal Record registers the sum of both cables.
On the UI, this means that if i am lifting 8.8 pounds, the record gets set to 17.6 pounds, even though only 1 cable is active.
To ensure that we are only setting records for 1 cable instead of 2 and also ensure that the reporting of cable weights is accurate for the chart movement data, we need to set some thresholds (this is related to stat-card reporting too).

This may impact alternating bicep curl or similar exercises, where the PR should be set to the max weight on 1 bicep, not both biceps (although this seems like a problematic exercise in itself for tracking per cable).