### PR TITLE
Guard bottom rep counter while stop-at-top is pending

### DIFF
--- a/workout-time/app.js
+++ b/workout-time/app.js
@@ -6207,6 +6207,14 @@ class VitruvianApp {
     }
 
     if (delta > 0) {
+      if (this._stopAtTopPending) {
+        this.addLogEntry(
+          "Stop-at-top pending; skipping bottom rep increment.",
+          "info",
+        );
+        this.lastRepCounter = completeCounter;
+        return;
+      }
       this.ensureWorkoutStartTime();
       // Rep completed! Record bottom position
       this.addLogEntry(


### PR DESCRIPTION
## Summary
- prevent bottom rep increments from firing while stop-at-top is pending
- log the skip so the workflow remains observable during the deferred stop sequence

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691678886e9c83218f07a4b6e92af5b3)