### PR TITLE
Skip flat adjustments for adaptive sets

### DIFF
--- a/js/builder.js
+++ b/js/builder.js
@@ -1646,11 +1646,12 @@ export const buildPlanSyncPayload = () => {
           occurrenceIndex
         );
         if (steps > 0) {
-          let nextWeight = item.perCableKg;
+          const basePerCableKg = item.perCableKg;
+          let nextWeight = basePerCableKg;
           if (hasPercent) {
-            nextWeight = item.perCableKg * (1 + (percent / 100) * steps);
-          } else if (hasFlat) {
-            nextWeight = item.perCableKg + flatKg * steps;
+            nextWeight = basePerCableKg * (1 + (percent / 100) * steps);
+          } else if (hasFlat && basePerCableKg > 0) {
+            nextWeight = basePerCableKg + flatKg * steps;
           }
           copy.perCableKg = roundKg(Math.max(0, nextWeight));
         }


### PR DESCRIPTION
## Summary
- prevent flat progression adjustments from applying to exercises without an existing load
- keep adaptive (zero-load) sets at zero while still honoring percent-based progressions

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a02b887483218c5f856ee2acd22d)