### PR TITLE
Ensure workout history resizes with sidebar

### DIFF
--- a/workout-time/index.html
+++ b/workout-time/index.html
@@ -200,6 +200,7 @@
             /* Main content area */
             .main-content {
                 flex: 1;
+                min-width: 0;
                 overflow-y: auto;
                 padding: 20px;
                 background: var(--main-bg);
@@ -2142,11 +2143,21 @@
             }
 
             /* Load graph */
+            #graphHistoryContainer,
+            #graphHistoryContainer > div {
+                min-width: 0;
+            }
+
             #loadGraphContainer {
                 background: var(--surface-subtle);
                 border-radius: 8px;
                 margin-bottom: 20px;
                 padding: 15px;
+                overflow: hidden;
+            }
+
+            #loadGraph {
+                width: 100%;
             }
 
             /* uPlot customization */
@@ -2282,6 +2293,10 @@
             }
 
             /* Workout history */
+            #historyList {
+                min-width: 0;
+            }
+
             .history-item {
                 background: white;
                 padding: 12px 15px;


### PR DESCRIPTION
Resolves #51 
## Summary
- allow the main content area to shrink when the sidebar is expanded
- ensure the load graph and history panels respect their container width on resize

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a656c2588321a8069ff6f3312bb1)