### PR TITLE
Added the missing repo guidance and described the new modules/tests s…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,19 +9,25 @@ This document orients automation and human collaborators to the structure, conve
 - `exercise_dump.json` — exported exercise metadata referenced by the app.
 - `js/` — modular ES modules that power the exercise plan builder (`builder.js`, `context.js`, `library.js`, etc.).
   - `plan-storage.js` centralises workout plan persistence. Interact with localStorage through the helpers exposed here rather than reimplementing storage access.
+  - `custom-exercises.js` merges Dropbox-backed custom exercises into `state.data`, assigns fresh identifiers, and exposes helpers for creating/syncing custom workout entries. Use its helpers instead of rebuilding catalogue math.
+  - `analytics-dashboard.js` powers the analytics tab, mapping Dropbox workouts + telemetry data into charts/statistics surfaced on the main site.
 - `workout-time/` — standalone Vitruvian workout control UI (`index.html`, `app.js`, supporting assets).
 - `shared/weight-utils.js` — single source of truth for kg/lb conversions; also attaches itself to `window.WeightUtils` so the workout-time console can reuse the same math.
+- `shared/echo-telemetry.js` — telemetry-processing helpers shared between the analytics dashboard and the workout-time console.
+- `tests/` — committed `node:test` specs (builder serialization, plan storage, search, workout console flows, and custom-workout creation).
 - `local-tests/` — lightweight Node-based test harness (builder, search, storage-sync, progression, and plan-runner tests).
 
 ## Key Flows
 - The builder UI is data-driven: `js/context.js` initializes shared state; `js/builder.js` consumes that state to serialize plans. Keep mutations centralized in `context.js` helpers.
+- Dropbox custom exercises are orchestrated through `js/main.js` + `custom-exercises.js`. Always use `buildCustomExerciseEntry`, `setCustomExercises`, and `getDropboxPayloadForCustomExercises` to keep IDs/search indexes consistent when creating custom workouts.
 - The workout control in `workout-time/app.js` communicates with hardware over WebSocket. Update connection logic cautiously; mirror any protocol changes in both UI and device code.
+- The analytics tab relies on `analytics-dashboard.js` and the shared telemetry helpers. Update those modules in tandem if telemetry schemas change.
 - Static assets are served as-is. No bundler is configured, so prefer vanilla JS modules and relative imports.
 - For storage interactions in the plan builder, rely on `plan-storage.js` helpers. They normalise plan names, manage the plan index, and guard against localStorage failures. Avoid duplicating that logic elsewhere to keep UI state and persistence consistent.
 
 ## Development Tips
 - Use `npx http-server .` or similar to preview pages locally. Both the root `index.html` and `workout-time/index.html` expect to run in a browser environment.
-- Run `npm test` (or `npm run test:local`) to sanity-check plan serialization/build flows alongside the browser search + storage helpers after modifying builder modules.
+- Run `npm run test:unit` for the committed `tests/` suite and `npm run test:local` for the optional `local-tests/` harness; `npm test` runs both. Always exercise the relevant suite(s) before syncing Dropbox data or sending PRs.
 - Run `npm run lint` before sending PRs so any trailing whitespace, loose equality, or rogue `var` declarations are caught early; `npm run format` will normalise whitespace/newlines when you need automatic fixes.
 - Maintain accessibility: new UI components should include keyboard support and ARIA labelling consistent with existing markup.
 - After touching persistence or plan-index flows, update `plan-storage.js` first and adapt consumers (currently `js/main.js`) to avoid drift between cached plan state and saved plans.
@@ -30,6 +36,7 @@ This document orients automation and human collaborators to the structure, conve
 ## Agent Guidance
 - When adding features, reflect changes in both the documentation and the relevant UI (root site vs. workout control panel) to keep experiences in sync.
 - Validate data contract changes against `exercise_dump.json` to avoid breaking the plan builder.
+- When handling Dropbox custom workouts, keep all merging/ID math inside `custom-exercises.js` so builder state, search indexes, and analytics stay aligned.
 - For styling adjustments, prefer editing `styles.css` or component-level `<style>` blocks; avoid inline styles unless scoped to dynamic states.
 - If any UI changes are made, take screenshots of new UI changes to ensure everything is working accordingly
 - Always run tests

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ Code structure (new modular layout)
 - `js/builder.js` — workout builder UI, drag-and-drop ordering, export/print/share actions.
 - `js/grouping.js` — grouping helpers (by equipment, muscles, or muscle groups) shared by builder.
 - `js/storage.js` — localStorage persistence, deep-link encoding, and workout restoration.
+- `js/custom-exercises.js` — merges Dropbox-backed custom exercises into the main catalogue, computes new identifiers, and exposes helpers for creating/syncing custom workout entries.
+- `js/analytics-dashboard.js` — renders the analytics tab, syncs Vitruvian workouts from Dropbox, and maps telemetry into charts/statistics.
 - `shared/weight-utils.js` — shared conversion helpers (kg/lb math) surfaced to both the Exercise Library and workout-time console.
+- `shared/echo-telemetry.js` — shared telemetry parsing helpers used by the analytics dashboard and the workout-time console.
 
 Each module is documented at the top to make it clear what part of the experience it owns. The builder and library modules also register a render callback so UI updates stay centralised in `main.js`.
 
@@ -34,10 +37,12 @@ Workout Time app structure
 - `workout-time/dropbox.js`, `device.js`, `chart.js`, `modes.js`, `protocol.js` — unchanged supporting modules for cloud sync, Bluetooth transport, charting, and protocol constants.
 - `workout-time/plan-runner.js` is loaded before `app.js`, so you can further extend the plan behaviour without reopening the main file.
 
-Local tests
+Automated tests
 
-- Run `npm test` to execute the repo’s Node suite plus every `local-tests/*.test.js` file; the local portion auto-skips if the directory is missing. Use `npm run test:local` to run just the local harness.
-- Tests live in `local-tests/` and are ignored by git so they never end up in commits. Run them directly with `node <file>` if you want to target a single script.
+- Run `npm run test:unit` to execute the committed Node suite in `tests/` (builder serialization, storage, search, workout console flows, and custom-workout creation coverage). Target a single file with `node tests/<file>.test.js`.
+- Run `npm run test:local` to execute the optional Node harness in `local-tests/`; it auto-skips when the directory is missing.
+- Run `npm test` to execute both suites; useful before syncing Dropbox plans or sharing builds.
+- The optional `local-tests/` scripts stay gitignored so debugging scaffolding never lands in commits. Run any script directly with `node local-tests/<file>.test.js`.
 - `node local-tests/builder.test.js` bootstraps a DOM stub, exports the builder via `buildPlanSyncPayload`, then reloads it with `loadPlanIntoBuilder` to ensure sets, videos, and progression metadata round-trip correctly.
 - `node local-tests/search.test.js` covers the fuzzy search scoring pipeline (token bonuses, cached index reuse, and substring fallbacks).
 - `node local-tests/storage-sync.test.js` exercises `plan-storage.js` by faking `localStorage` to verify plan indexing, persistence, and deletion flows.

--- a/tests/custom-workout-creation.test.js
+++ b/tests/custom-workout-creation.test.js
@@ -1,0 +1,256 @@
+import test, { beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWindowStub } from './helpers/vitruvian-test-utils.js';
+
+const windowStub = createWindowStub();
+globalThis.window = windowStub;
+globalThis.document = windowStub.document;
+globalThis.localStorage = windowStub.localStorage;
+
+const { state, getSearchIndex, setSearchIndex } = await import('../js/context.js');
+const {
+  setBaseExercises,
+  setCustomExercises,
+  getCustomExercises,
+  buildCustomExerciseEntry,
+  getNextCustomNumericId,
+  getDropboxPayloadForCustomExercises
+} = await import('../js/custom-exercises.js');
+
+const cloneExercise = (exercise) => {
+  if (!exercise || typeof exercise !== 'object') return exercise;
+  return {
+    ...exercise,
+    muscleGroups: Array.isArray(exercise.muscleGroups) ? [...exercise.muscleGroups] : undefined,
+    muscles: Array.isArray(exercise.muscles) ? [...exercise.muscles] : undefined,
+    equipment: Array.isArray(exercise.equipment) ? [...exercise.equipment] : undefined,
+    summary: exercise.summary
+      ? {
+          muscles: Array.isArray(exercise.summary.muscles) ? [...exercise.summary.muscles] : [],
+          equipment: Array.isArray(exercise.summary.equipment) ? [...exercise.summary.equipment] : []
+        }
+      : undefined,
+    videos: Array.isArray(exercise.videos) ? [...exercise.videos] : undefined
+  };
+};
+
+const cloneExerciseList = (list) => (Array.isArray(list) ? list.map((exercise) => cloneExercise(exercise)) : []);
+
+let originalState;
+let originalSearchIndex;
+
+beforeEach(() => {
+  originalState = {
+    data: cloneExerciseList(state.data),
+    baseExercises: cloneExerciseList(state.data.filter((exercise) => !exercise?.isCustom)),
+    muscles: [...state.muscles],
+    subMuscles: [...state.subMuscles],
+    equipment: [...state.equipment],
+    customExercises: cloneExerciseList(state.customExercises),
+    randomOrderMap: state.randomOrderMap instanceof Map ? new Map(state.randomOrderMap) : state.randomOrderMap ?? null
+  };
+  originalSearchIndex = getSearchIndex();
+  setBaseExercises([]);
+  setCustomExercises([]);
+});
+
+afterEach(() => {
+  setBaseExercises(originalState.baseExercises);
+  setCustomExercises(originalState.customExercises);
+  state.data = cloneExerciseList(originalState.data);
+  state.muscles = [...originalState.muscles];
+  state.subMuscles = [...originalState.subMuscles];
+  state.equipment = [...originalState.equipment];
+  state.customExercises = cloneExerciseList(originalState.customExercises);
+  state.randomOrderMap =
+    originalState.randomOrderMap instanceof Map
+      ? new Map(originalState.randomOrderMap)
+      : originalState.randomOrderMap ?? null;
+  setSearchIndex(originalSearchIndex);
+});
+
+test('setCustomExercises merges Dropbox entries so custom workouts show up in the builder catalogue', () => {
+  const baseExercises = [
+    {
+      id: 'deadlift',
+      id_new: 410,
+      name: 'Conventional Deadlift',
+      muscleGroups: ['Posterior Chain'],
+      muscles: ['Spinal Erectors'],
+      equipment: ['Barbell'],
+      summary: {
+        muscles: ['Posterior Chain'],
+        equipment: ['Barbell']
+      }
+    },
+    {
+      id: 'splitSquat',
+      id_new: 411,
+      name: 'Split Squat',
+      muscleGroups: ['Legs'],
+      muscles: ['Quads'],
+      equipment: ['Dumbbell'],
+      summary: {
+        muscles: ['Legs'],
+        equipment: ['Dumbbell']
+      }
+    }
+  ];
+  const remoteCustomExercises = [
+    {
+      id: 'custom-612',
+      id_new: 612,
+      name: 'Tempo Row',
+      muscleGroups: ['Back'],
+      muscles: [],
+      equipment: ['Cable'],
+      summary: {
+        muscles: [],
+        equipment: []
+      }
+    }
+  ];
+
+  setBaseExercises(baseExercises);
+  setCustomExercises(remoteCustomExercises);
+
+  assert.deepStrictEqual(
+    state.data.map((exercise) => exercise.id),
+    ['deadlift', 'splitSquat', 'custom-612'],
+    'builder catalogue should include base + custom exercises'
+  );
+
+  const catalogueCustom = state.data.find((exercise) => exercise.id === 'custom-612');
+  assert.ok(catalogueCustom?.isCustom, 'custom entries should be tagged');
+  assert.deepStrictEqual(
+    catalogueCustom?.summary,
+    { muscles: ['Back'], equipment: ['Cable'] },
+    'missing summary data should fall back to chosen tags so filters stay in sync'
+  );
+
+  assert.deepStrictEqual(
+    [...state.muscles].sort(),
+    ['Back', 'Legs', 'Posterior Chain'],
+    'muscle group filters should reflect the merged catalogue'
+  );
+  assert.deepStrictEqual(
+    [...state.equipment].sort(),
+    ['Barbell', 'Cable', 'Dumbbell'],
+    'equipment filters should reflect the merged catalogue'
+  );
+
+  const searchIndex = getSearchIndex();
+  assert.ok(searchIndex instanceof Map, 'custom entries should trigger a rebuilt search index');
+  assert.ok(searchIndex.has('custom-612'), 'custom entries should be searchable for workout creation');
+
+  const exportedCustomExercises = getCustomExercises();
+  assert.notStrictEqual(
+    exportedCustomExercises[0],
+    state.customExercises[0],
+    'callers should receive a clone so builder mutations cannot affect Dropbox payloads'
+  );
+
+  // Mutate the exported copy and verify it does not leak back into state.
+  exportedCustomExercises[0].name = 'Modified Tempo Row';
+  assert.notStrictEqual(
+    exportedCustomExercises[0].name,
+    state.customExercises[0].name,
+    'state should remain unchanged when consumers edit the exported list'
+  );
+});
+
+test('buildCustomExerciseEntry normalizes metadata for newly created custom workouts', () => {
+  setBaseExercises([
+    {
+      id: 'baseBench',
+      id_new: 700,
+      name: 'Base Bench',
+      muscleGroups: ['Chest'],
+      muscles: ['Pecs'],
+      equipment: ['Barbell']
+    }
+  ]);
+  setCustomExercises([
+    {
+      id: 'custom-701',
+      id_new: 701,
+      name: 'Existing Custom',
+      muscleGroups: ['Arms'],
+      muscles: ['Biceps'],
+      equipment: ['Cable']
+    }
+  ]);
+
+  const RealDate = Date;
+  const fixedDate = new RealDate('2024-01-02T03:04:05.000Z');
+  // eslint-disable-next-line no-global-assign
+  Date = class MockDate extends RealDate {
+    constructor(...args) {
+      if (args.length === 0) {
+        return new RealDate(fixedDate);
+      }
+      return new RealDate(...args);
+    }
+    static now() {
+      return fixedDate.getTime();
+    }
+    static parse(value) {
+      return RealDate.parse(value);
+    }
+    static UTC(...args) {
+      return RealDate.UTC(...args);
+    }
+  };
+
+  try {
+    const entry = buildCustomExerciseEntry({
+      name: '  tempo pull  ',
+      muscleGroups: [' Back ', 'Core', '', null],
+      muscles: [' Lats', 'Upper Back'],
+      equipment: [' Cable ', ' Bench', '']
+    });
+
+    assert.equal(entry.id_new, 702, 'new custom workouts should use the next numeric id');
+    assert.equal(entry.id, 'custom-702');
+    assert.equal(entry.name, 'tempo pull', 'names should be trimmed but otherwise preserved');
+    assert.equal(entry.created, fixedDate.toISOString());
+    assert.deepStrictEqual(entry.muscleGroups, ['Back', 'Core']);
+    assert.deepStrictEqual(entry.muscles, ['Lats', 'Upper Back']);
+    assert.deepStrictEqual(entry.equipment, ['Cable', 'Bench']);
+    assert.deepStrictEqual(
+      entry.summary,
+      {
+        muscles: ['Back', 'Core'],
+        equipment: ['Cable', 'Bench']
+      },
+      'summary should mirror the picker selections when no explicit summary is supplied'
+    );
+    assert.deepStrictEqual(entry.videos, []);
+    assert.equal(entry.isCustom, true);
+
+    const nextId = getNextCustomNumericId();
+    assert.equal(nextId, 703, 'custom workout ids should continue incrementing after entry creation');
+
+    const syncPayload = getDropboxPayloadForCustomExercises([entry]);
+    assert.deepStrictEqual(syncPayload, [
+      {
+        id: 'custom-702',
+        id_new: 702,
+        name: 'tempo pull',
+        created: fixedDate.toISOString(),
+        muscleGroups: ['Back', 'Core'],
+        muscles: ['Lats', 'Upper Back'],
+        equipment: ['Cable', 'Bench'],
+        summary: {
+          muscles: ['Back', 'Core'],
+          equipment: ['Cable', 'Bench']
+        },
+        videos: []
+      }
+    ]);
+  } finally {
+    // eslint-disable-next-line no-global-assign
+    Date = RealDate;
+  }
+});


### PR DESCRIPTION
…o contributors know where the Dropbox-powered custom workouts and analytics logic live (README.md (lines 16-50), AGENTS.md (lines 6-43)). Introduced tests/custom-workout-creation.test.js (lines 1-231), which stubs the DOM, verifies that Dropbox-synced custom exercises get merged into the builder catalogue, and ensures buildCustomExerciseEntry generates sanitized, sequential IDs plus Dropbox-ready payloads for new custom workouts.